### PR TITLE
color support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.2-alpha",
       "license": "MIT",
       "dependencies": {
+        "color-parse": "^2.0.2",
         "fabric": "^5.3.0",
         "fabricjs-react": "^1.2.2",
         "uuid": "^10.0.0"
@@ -8154,6 +8155,22 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/color-parse/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "react-canvas-annotator"
   ],
   "dependencies": {
+    "color-parse": "^2.0.2",
     "fabric": "^5.3.0",
     "fabricjs-react": "^1.2.2",
     "uuid": "^10.0.0"

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -6,6 +6,7 @@ import { CanvasObject } from "./types";
 import * as fabricUtils from "../../fabric/utils";
 import * as fabricActions from "../../fabric/actions";
 import * as fabricTypes from "../../fabric/types";
+import parse from "color-parse";
 
 export type BoardProps = {
   items: CanvasObject[];
@@ -458,7 +459,11 @@ const Board = React.forwardRef<BoardActions, BoardProps>(
         const polygon = fabricUtils.createControllableCustomObject(
           fabric.Polygon,
           scaledCoords,
-          { name: `ID_${item.id}` },
+          {
+            name: `ID_${item.id}`,
+            stroke: item.color,
+            fill: `rgba(${parse(item.color).values.join(",")},${item.opacity ?? 0.4})`,
+          },
           scaledCoords.length === 4, // Is a rectangle
         );
         canvas.add(polygon);

--- a/src/components/Board/types.tsx
+++ b/src/components/Board/types.tsx
@@ -4,4 +4,5 @@ export type CanvasObject = {
   color: string;
   value: string;
   coords: { x: number; y: number }[];
+  opacity?: number;
 };


### PR DESCRIPTION
### Description

Colors (for border) defined in the items are now supported. Added optional opacity option as well for the fill color

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->


- [x] New Feature

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/dansreis/react-canvas-annotator/blob/main/CONTRIBUTING.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).