### PR TITLE
Enable dragging by default when nothing is selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ All of the following properties can be defined on the `Board` component:
 | `initialStatus`    | `{ draggingEnabled?: boolean; currentZoom?: number; scaleRatio?: number; }` | Initial status settings for dragging, zoom level, and scale ratio.                                | {}            |
 | `onResetZoom`      | `() => void`                                    | Callback function to handle zoom reset action.                                                    |               |
 | `onZoomChange`     | `(currentZoom: number) => void`                 | Callback function triggered when the zoom level changes.                                          |               |
-| `onToggleDragging` | `(currentStatus: boolean) => void`              | Callback function triggered when dragging is toggled.                                             |               |
 | `onLoadedImage`    | `({ width, height }: { width: number; height: number; }) => void` | Callback function triggered when the image has been successfully loaded, providing its dimensions. |               |
 
 *(Properties marked with \* are required)*

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -195,7 +195,7 @@ const Board = React.forwardRef<BoardActions, BoardProps>(
         },
       );
 
-      // On Mouse right click (down)
+      // On Mouse left click (down)
       editor.canvas.on(
         "mouse:down",
         function (this: fabricTypes.CanvasAnnotationState, opt) {
@@ -276,13 +276,13 @@ const Board = React.forwardRef<BoardActions, BoardProps>(
         },
       );
 
-      // On Mouse right click (up)
+      // On Mouse left click (up)
       editor.canvas.on(
         "mouse:up",
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         function (this: fabricTypes.CanvasAnnotationState, _opt) {
           if (this.isDragging) {
-            // Rese the  viewport
+            // Reset the viewport
             editor.canvas.zoomToPoint(
               { x: _opt.e.offsetX, y: _opt.e.offsetY },
               editor.canvas.getZoom(),

--- a/src/components/Board/__docs__/Board.mdx
+++ b/src/components/Board/__docs__/Board.mdx
@@ -50,7 +50,5 @@ export default Example;
 
 `currentZoom`: Number representing the current zoom level.
 
-- **onToggleDragging**: `(currentStatus: boolean) => void` -  Optional callback function called when dragging status changes.
-
 - **currentStatus**: Boolean indicating the current dragging status.
 - **onLoadedImage**: `({ width, height }: { width: number, height: number }) => void` -  Optional callback function called when the image is loaded (width: Width of the loaded image, height: Height of the loaded image).

--- a/src/components/Board/__docs__/Example.tsx
+++ b/src/components/Board/__docs__/Example.tsx
@@ -4,7 +4,6 @@ import Board, { BoardActions, BoardProps } from "../Board";
 const Example: FC<BoardProps> = ({ items, image }) => {
   const ref = React.createRef<BoardActions>();
 
-  const [toggleStatus, setToggleStatus] = useState(false);
   const [isDrawingPolygon, setIsDrawingPolygon] = useState(false);
   const [isDrawingRectangle, setIsDrawingRectangle] = useState(false);
   const [currentZoom, setCurrentZoom] = useState<number | undefined>();
@@ -12,9 +11,6 @@ const Example: FC<BoardProps> = ({ items, image }) => {
   return (
     <>
       <div style={{ display: "flex", gap: "10px" }}>
-        <button onClick={() => ref.current?.toggleDragging()}>
-          Toggle Dragging [{toggleStatus ? "ON" : "OFF"}]
-        </button>
         <button onClick={() => ref.current?.resetZoom()}>Reset Zoom</button>
         <button onClick={() => ref.current?.deleteSelectedObjects()}>
           Delete Selected
@@ -69,7 +65,6 @@ const Example: FC<BoardProps> = ({ items, image }) => {
           ref={ref}
           image={image}
           items={items}
-          onToggleDragging={(s) => setToggleStatus(s)}
           onZoomChange={(v) => setCurrentZoom(v)}
         />
       </div>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Don't require hook to control dragging status. Infer it automatically


---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [X] New Feature

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/dansreis/react-canvas-annotator/blob/main/CONTRIBUTING.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).