### PR TITLE
Disable uniform scaling of objects on canvas

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -167,6 +167,9 @@ const Board = React.forwardRef<BoardActions, BoardProps>(
       // Change the cursor
       editor.canvas.defaultCursor = draggingEnabled ? "pointer" : "default";
 
+      // Disable uniform scaling
+      editor.canvas.uniformScaling = false;
+
       fabric.Image.fromURL(
         image.src,
         (img) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Disable uniform scaling of objects

### Additional context

Fix weird behaviour of keeping rectangle scale while resizing object on corners

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/dansreis/react-canvas-annotator/blob/main/CONTRIBUTING.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).