### PR TITLE
Allow user to disable retrieving content from 'retrieveObjects'

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -36,7 +36,7 @@ export type BoardActions = {
   deselectAll: () => void;
   downloadImage: () => void;
   drawObject: (type?: "rectangle" | "polygon") => void;
-  retrieveObjects: () => CanvasObject[];
+  retrieveObjects: (includeContent?: boolean) => CanvasObject[];
   retrieveObjectContent: (id: string) => string | null;
 };
 
@@ -101,14 +101,14 @@ const Board = React.forwardRef<BoardActions, BoardProps>(
       downloadImage() {
         fabricActions.canvasImageDownload(image);
       },
-      retrieveObjects: () => {
+      retrieveObjects: (includeContent: boolean = true) => {
         const canvas = editor?.canvas;
         if (canvas) {
           const customObjects =
             fabricUtils.retrieveObjects<fabricTypes.CustomObject>(canvas);
           if (!customObjects) return [];
           return customObjects.map((co) => {
-            const info = getObjectInfo(co);
+            const info = getObjectInfo(co, includeContent);
 
             return {
               id: co.name!,
@@ -165,7 +165,10 @@ const Board = React.forwardRef<BoardActions, BoardProps>(
       setDrawingObject(state);
     }, [editor?.canvas]);
 
-    const getObjectInfo = (obj: fabricTypes.CustomObject) => {
+    const getObjectInfo = (
+      obj: fabricTypes.CustomObject,
+      includeContent = true,
+    ) => {
       const width = editor?.canvas.getWidth() ?? 0;
       const height = editor?.canvas.getHeight() ?? 0;
       const updatedCoordPoints = fabricUtils.pointsInCanvas(obj);
@@ -183,10 +186,12 @@ const Board = React.forwardRef<BoardActions, BoardProps>(
 
       return {
         coords: updatedCoords,
-        content: originalFabricImage?.toDataURL({
-          withoutTransform: true,
-          ...fabricUtils.getBoundingBox(updatedCoords),
-        }),
+        content: includeContent
+          ? originalFabricImage?.toDataURL({
+              withoutTransform: true,
+              ...fabricUtils.getBoundingBox(updatedCoords),
+            })
+          : undefined,
       };
     };
 


### PR DESCRIPTION
### Description

Allow user to disable retrieving content from 'retrieveObjects' method

### Additional context

N/A

---

### What is the purpose of this pull request?

- [X] New Feature

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/dansreis/react-canvas-annotator/blob/main/CONTRIBUTING.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).